### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# editorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+
+[*.{json,yml,babelrc}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
An [editorconfig](http://editorconfig.org) that covers *.js *.json *.yml, babelrc, and Makefile

supports:
- [atom](https://github.com/sindresorhus/atom-editorconfig)
- [vim](https://github.com/editorconfig/editorconfig-vim)
- [sublime text](https://github.com/sindresorhus/editorconfig-sublime)

cc @mikeliu32 